### PR TITLE
Try and replace missing dask imports

### DIFF
--- a/intake/container/persist.py
+++ b/intake/container/persist.py
@@ -49,12 +49,12 @@ class PersistStore(YAMLFileCatalog):
 
     def __init__(self, path=None):
         # from fsspec.registry import filesystem
-        from dask.bytes.core import get_fs_token_paths
+        from fsspec import filesystem
         self.pdir = make_path_posix(path or conf.get('persist_path'))
         path = posixpath.join(self.pdir, 'cat.yaml')
         protocol = (self.pdir.split('://', 1)[0]
                     if "://" in self.pdir else 'file')
-        self.fs = get_fs_token_paths(protocol)[0]
+        self.fs = filesystem(protocol)
         _maybe_add_rm(self.fs)
         super(PersistStore, self).__init__(path)
 

--- a/intake/container/persist.py
+++ b/intake/container/persist.py
@@ -20,7 +20,7 @@ from ..utils import make_path_posix
 def _maybe_add_rm(fs):
     # monkey-path local filesystem
     # this goes away if we can use fsspec's local file-system
-    from dask.bytes.local import LocalFileSystem
+    from fsspec.implementations.local import LocalFileSystem
     if isinstance(fs, LocalFileSystem):
         def rm(path, recursive=False):
             if recursive:
@@ -49,12 +49,12 @@ class PersistStore(YAMLFileCatalog):
 
     def __init__(self, path=None):
         # from fsspec.registry import filesystem
-        from dask.bytes.core import get_fs
+        from dask.bytes.core import get_fs_token_paths
         self.pdir = make_path_posix(path or conf.get('persist_path'))
         path = posixpath.join(self.pdir, 'cat.yaml')
         protocol = (self.pdir.split('://', 1)[0]
                     if "://" in self.pdir else 'file')
-        self.fs = get_fs(protocol)[0]
+        self.fs = get_fs_token_paths(protocol)[0]
         _maybe_add_rm(self.fs)
         super(PersistStore, self).__init__(path)
 

--- a/intake/source/cache.py
+++ b/intake/source/cache.py
@@ -17,7 +17,7 @@ import re
 import shutil
 import warnings
 
-from dask.bytes.core import infer_storage_options
+from fsspec.utils import infer_storage_options
 from intake.config import conf
 from intake.utils import make_path_posix
 

--- a/intake/source/cache.py
+++ b/intake/source/cache.py
@@ -17,7 +17,7 @@ import re
 import shutil
 import warnings
 
-from dask.bytes.utils import infer_storage_options
+from dask.bytes.core import infer_storage_options
 from intake.config import conf
 from intake.utils import make_path_posix
 


### PR DESCRIPTION
@martindurant I am trying to implement some change in intake-xarray to use get_mapper from fsspec as you suggested in https://github.com/intake/intake-xarray/pull/42.

After upgrading gcsfs I hit some issues similar to https://github.com/dask/gcsfs/issues/162 and installed dask from master as you mentioned. But this resulted in a few missing imports which I'm attempting to fix in this pull request. I also had some import errors in intake-xarray which I tried to fix in https://github.com/intake/intake-xarray/pull/42/commits/dfd77b8e649c9a767b3155173e7c5cf321d1ba81.

I got stuck now trying to open some zarr stored in GCS from an intake catalog, this is how the traceback looks like:

```
In [4]: ds = cat.consultancy.bom_ww3_oceania.to_dask()                                                                                                   
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-ca35c16c786f> in <module>
----> 1 ds = cat.consultancy.bom_ww3_oceania.to_dask()

/source/fork/intake-xarray/intake_xarray/base.py in to_dask(self)
     67     def to_dask(self):
     68         """Return xarray object where variables are dask arrays"""
---> 69         return self.read_chunked()
     70 
     71     def close(self):

/source/fork/intake-xarray/intake_xarray/base.py in read_chunked(self)
     42     def read_chunked(self):
     43         """Return xarray object (which will have chunks)"""
---> 44         self._load_metadata()
     45         return self._ds
     46 

/source/fork/intake-mdurant/intake/source/base.py in _load_metadata(self)
    115         """load metadata only if needed"""
    116         if self._schema is None:
--> 117             self._schema = self._get_schema()
    118             self.datashape = self._schema.datashape
    119             self.dtype = self._schema.dtype

/source/fork/intake-xarray/intake_xarray/base.py in _get_schema(self)
     16 
     17         if self._ds is None:
---> 18             self._open_dataset()
     19 
     20             metadata = {

/source/fork/intake-xarray/intake_xarray/xzarr.py in _open_dataset(self)
     30         from dask.bytes.core import get_fs_token_paths, infer_storage_options
     31         urlpath, protocol, options = infer_storage_options(self.urlpath)
---> 32         update_storage_options(options, self.storage_options)
     33 
     34         self._fs, _ = get_fs_token_paths(protocol, options)

~/Envs/py3/lib/python3.7/site-packages/fsspec/utils.py in update_storage_options(options, inherited)
    100         raise KeyError("Collision between inferred and specified storage "
    101                        "options:\n%s" % collisions)
--> 102     options.update(inherited)
    103 
    104 

AttributeError: 'str' object has no attribute 'update'
```